### PR TITLE
[cmake] get rid of undefined HAVE_GRIDTYPE warning

### DIFF
--- a/cmake/modules/GridType.cmake
+++ b/cmake/modules/GridType.cmake
@@ -26,8 +26,11 @@ macro(dune_define_gridtype output)
    The required headers for this grid implementation are also included.
 */
 #if HAVE_DUNE_GRID && defined ${GRIDTYPE_GRIDTYPE} && ! defined USED_${GRIDTYPE_GRIDTYPE}_GRIDTYPE
+  #ifndef HAVE_GRIDTYPE
+    #define HAVE_GRIDTYPE 0
+  #endif
   #if HAVE_GRIDTYPE
-   #error \"Ambiguous definition of GRIDTYPE.\"
+    #error \"Ambiguous definition of GRIDTYPE.\"
   #endif
 
   #ifndef WORLDDIM
@@ -59,6 +62,7 @@ macro(dune_define_gridtype output)
       typedef ${GRIDTYPE_DUNETYPE} GridType;
     }
   }
+  #undef HAVE_GRIDTYPE
   #define HAVE_GRIDTYPE 1
   #define USED_${GRIDTYPE_GRIDTYPE}_GRIDTYPE 1
 #endif // #if HAVE_DUNE_GRID && defined ${GRIDTYPE_GRIDTYPE} && ..")


### PR DESCRIPTION
This commit gets rid of a warning for me. It is tested with v2.3.1 but it should work on current master as well.
The whitespace change in line 30 is introduced to make the indentation consistent with the rest of this block.

P.S.: I know that this is not your favorite way of getting patches but I hope someone gets notified of this never the less.