### PR TITLE
Printgrid improvements

### DIFF
--- a/dune/grid/io/file/printgrid.hh
+++ b/dune/grid/io/file/printgrid.hh
@@ -53,7 +53,7 @@ namespace Dune {
 
   }
 
-  /** \brief Print a grid as a gnuplot for testing and development
+  /** \brief Print a 2D grid as a gnuplot for testing and development
    *  \tparam GridType the type of grid to work with
    *  \param grid the grid to print
    *  \param output_file the base of the output filename
@@ -70,6 +70,8 @@ namespace Dune {
                   int size = 2000, bool execute_plot = true, bool png = true, bool local_corner_indices = true,
                   bool local_intersection_indices = true, bool outer_normals = true)
   {
+    // Assert correct dimension
+    static_assert (GridType::dimension == 2, "printgrid only supports 2D grids!");
 
     // Create output file
     if (grid.comm().size() > 1)

--- a/dune/grid/io/file/test/printgridtest.cc
+++ b/dune/grid/io/file/test/printgridtest.cc
@@ -19,7 +19,6 @@ int main(int argc, char **argv)
     Dune::FieldVector<double,dim> L(1.0);
     std::array<int,dim> N(Dune::fill_array<int,dim>(4));
     std::bitset<dim> periodic (false);
-    periodic[0] = true;
     int overlap = 1;
     Dune::YaspGrid<dim> grid(L,N,periodic, overlap);
 

--- a/dune/grid/io/file/test/printgridtest.cc
+++ b/dune/grid/io/file/test/printgridtest.cc
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; indent-tabs-mode: nil -*-
 
-// Based on: Boilerplate tutorial poisson_uniform.cc
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -14,7 +12,7 @@ int main(int argc, char **argv)
 {
   try {
     // initialize MPI, finalize is done automatically on exit
-    Dune::MPIHelper& helper = Dune::MPIHelper::instance(argc,argv);
+    Dune::MPIHelper::instance(argc,argv);
 
     // make grid
     const int dim = 2;
@@ -26,8 +24,8 @@ int main(int argc, char **argv)
     Dune::YaspGrid<dim> grid(L,N,periodic, overlap);
 
     // write .plt files (one for png, one for svg) without executing gnuplot on them
-    Dune::printgrid (grid, helper, "printgridtest_yasp_svg", 4000, false, false);
-    Dune::printgrid (grid, helper, "printgridtest_yasp_png", 4000, false);
+    Dune::printgrid (grid, "printgridtest_yasp_svg", 4000, false, false);
+    Dune::printgrid (grid, "printgridtest_yasp_png", 4000, false);
   } catch (Dune::Exception &e) {
     std::cerr << e << std::endl;
     return 1;


### PR DESCRIPTION
- Removed mpihelper argument; retrieve it from grid instead
- Avoid a compiler warning on the gnuplot call; throw an error if it fails
