### PR TITLE
[OneDGrid] Assert that vertices are specified when OneDGrid is initialized

### DIFF
--- a/dune/grid/onedgrid/onedgridfactory.cc
+++ b/dune/grid/onedgrid/onedgridfactory.cc
@@ -82,6 +82,9 @@ createGrid()
   if (grid_==NULL)
     return NULL;
 
+  // Assert that vertices are given
+  assert (vertexPositions_.size() > 0);
+
   // ////////////////////////////////////////////////////////
   //   Insert the vertices into the grid
   // ////////////////////////////////////////////////////////


### PR DESCRIPTION
When OneDGrid is initialized without content (happened to me accidentally), it causes funny crashes due to
for (size_t i=0; i<vertexPositions_.size()-1; i++, ++eIt) {
with vertexPositions_.size() being unsigned.
Maybe we should add this assert to prevent that?
